### PR TITLE
chore: switch dependabot to weekly schedule with dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: daily
+      interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Switch all dependabot update schedules from daily to weekly and add an `all-dependencies` group for each ecosystem, so updates are batched into a single PR per toolchain rather than one PR per package.